### PR TITLE
link to markdown rendered contribution guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ java -jar droidefense-cli-1.0-SNAPSHOT.jar -i /path/to/your/sample.apk
 
 # Contributing
 
-Everybody is welcome to contribute to **DROIDEFENSE**. Please check out the [**DROIDEFENSE Contribution Steps**](https://raw.githubusercontent.com/droidefense/engine/develop/CONTRIBUTING.md) for instructions about how to proceed.
+Everybody is welcome to contribute to **DROIDEFENSE**. Please check out the [**DROIDEFENSE Contribution Steps**](https://github.com/droidefense/engine/blob/develop/CONTRIBUTING.md) for instructions about how to proceed.
   
 And any other comments will be very appreciate.
 


### PR DESCRIPTION
The current README link currently links to the raw CONTRIBUTING.md file, which isn't too user friendly or readable. It might be nicer to link to the markdown rendered version instead to make it easier to read.